### PR TITLE
Add query parsing and visualization

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -73,7 +73,7 @@ st.markdown("""
     
     /* Progress bar customization */
     .stProgress > div > div > div > div {
-        background-color: #f7f6ed;
+        background-color: #18ff4e;
     }
     
     /* Score badge */
@@ -98,6 +98,12 @@ st.markdown("""
     .score-low {
         background-color: #F8D7DA;
         color: #721C24;
+    }
+
+    /* Content preview container */
+    .content-preview {
+        max-width: 50rem;
+        margin: 0 auto;
     }
 </style>
 """, unsafe_allow_html=True)
@@ -154,7 +160,9 @@ AGENT_PROMPTS = {
        - Trust-building credibility markers
        - Common pitfalls to avoid (buzzwords, jargon, condescension)
     
-    Remember: You're setting up the team for success. Be specific, practical, and always keep the reader's needs at the center.""",
+    Remember: You're setting up the team for success. Be specific, practical, and always keep the reader's needs at the center.
+
+When you finish, add a section titled 'Recommended Next Steps:' followed by a bullet list of actionable suggestions.""",
     
     "Specialist Writer": """You are Momentic's Senior Technical Content Writer, specializing in making complex technical concepts accessible without dumbing them down. You have a background in software development and understand that great technical writing respects the reader's intelligence while ensuring clarity.
 
@@ -181,7 +189,9 @@ AGENT_PROMPTS = {
     - Use "you" to speak directly to the reader
     - Avoid buzzwords and corporate jargon entirely
     
-    Your goal: Create content that a senior developer would actually bookmark and share with their team.""",
+    Your goal: Create content that a senior developer would actually bookmark and share with their team.
+
+When you finish, add a section titled 'Recommended Next Steps:' followed by a bullet list of actionable suggestions.""",
         
     "SEO Specialist": """You are Aurora-SEO at Momentic, a future-proof search strategist and relevance engineer specializing in driving organic impact across classic SERPs and AI surfaces (AI Overviews, AI Mode, ChatGPT, Perplexity).
     
@@ -218,7 +228,9 @@ AGENT_PROMPTS = {
     - Flag uncertainty rather than fabricate metrics
     - Include measurement hooks for citation frequency and answer prominence
     
-    Never sacrifice readability for traditional SEO metrics. The best content serves users first and search engines second.""",
+    Never sacrifice readability for traditional SEO metrics. The best content serves users first and search engines second.
+
+When you finish, add a section titled 'Recommended Next Steps:' followed by a bullet list of actionable suggestions.""",
     
     "Head of Content": """You are Momentic's Head of Content with 15+ years in B2B tech content leadership. You've built content programs that establish market authority while driving real business results. You review content through both strategic and practical lenses.
 
@@ -255,7 +267,9 @@ AGENT_PROMPTS = {
     4) Add CTAs that feel genuinely helpful, never pushy
     5) Polish for memorability - what's the one thing readers will remember?
     
-    Your goal: Elevate good content to exceptional. Make it something you'd be proud to put your name on.""",
+    Your goal: Elevate good content to exceptional. Make it something you'd be proud to put your name on.
+
+When you finish, add a section titled 'Recommended Next Steps:' followed by a bullet list of actionable suggestions.""",
     
     "Editor-in-Chief": """You are Momentic's Editor-in-Chief, the final guardian of content quality and brand reputation. You've edited thousands of technical articles and have developed an instinct for what truly serves technical audiences.
 
@@ -309,7 +323,9 @@ AGENT_PROMPTS = {
     FINAL_TITLE: [The polished, publication-ready title]
     FINAL_SLUG: [SEO-optimized URL slug]
     
-    Editor's instinct: Would YOU save this article? Would you share it with a colleague?"""
+    Editor's instinct: Would YOU save this article? Would you share it with a colleague?
+
+When you finish, add a section titled 'Recommended Next Steps:' followed by a bullet list of actionable suggestions."""
 }
 
 def extract_text_from_file(uploaded_file):
@@ -350,11 +366,22 @@ def call_agent(agent_name, prompt, model, api_key, context=""):
         st.error(f"Error calling {agent_name}: {str(e)}")
         return None
 
+def parse_next_steps(output):
+    """Split agent output into main content and bullet list of next steps"""
+    if "Recommended Next Steps:" in output:
+        content, steps_part = output.split("Recommended Next Steps:", 1)
+        steps = [
+            line.strip("- ").strip()
+            for line in steps_part.strip().splitlines()
+            if line.strip().startswith("-")
+        ]
+        return content.strip(), steps
+    return output.strip(), []
+
 def parse_queries(text: str) -> list[str]:
-    """Extract list of search queries from the SEO Specialist output."""
+    """Extract search queries from SEO Specialist output."""
 
     queries: list[str] = []
-
     bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
 
     for line in text.splitlines():
@@ -367,7 +394,13 @@ def parse_queries(text: str) -> list[str]:
     return queries
 
 def run_content_pipeline(inputs, model, api_key, status_container, progress_bar):
-    """Run the full 5-agent content creation pipeline"""
+    """Run the full 5-agent content creation pipeline
+
+    Parameters
+    ----------
+    status_container : st.container
+        Sidebar container used to display stage status messages.
+    """
     
     # Extract inputs
     content_type = inputs["content_type"]
@@ -381,6 +414,7 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     references = inputs["references"]
     
     results = {}
+    next_steps = {}
     
     # Stage 1: Strategist
     start_time = datetime.now()
@@ -398,11 +432,12 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     Create a comprehensive content strategy with outline.
     """
     
-    strategy = call_agent("Strategist", strategist_prompt, model, api_key)
-    if not strategy:
+    strategy_raw = call_agent("Strategist", strategist_prompt, model, api_key)
+    if not strategy_raw:
         return None
-    
+    strategy, steps = parse_next_steps(strategy_raw)
     results["strategy"] = strategy
+    next_steps["Strategist"] = steps
     progress_bar.progress(0.2)
     
     # Stage 2: Specialist Writer
@@ -419,11 +454,12 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     Voice: {brand_voice or 'Professional, data-driven, friendly'}
     """
     
-    draft = call_agent("Specialist Writer", writer_prompt, model, api_key)
-    if not draft:
+    draft_raw = call_agent("Specialist Writer", writer_prompt, model, api_key)
+    if not draft_raw:
         return None
-    
+    draft, steps = parse_next_steps(draft_raw)
     results["draft"] = draft
+    next_steps["Specialist Writer"] = steps
     progress_bar.progress(0.4)
     
     # Stage 3: SEO Specialist
@@ -438,12 +474,13 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     Return the full content with SEO improvements applied.
     """
     
-    seo_content = call_agent("SEO Specialist", seo_prompt, model, api_key)
-    if not seo_content:
+    seo_raw = call_agent("SEO Specialist", seo_prompt, model, api_key)
+    if not seo_raw:
         return None
-
+    seo_content, steps = parse_next_steps(seo_raw)
     results["seo_content"] = seo_content
     results["queries"] = parse_queries(seo_content)
+    next_steps["SEO Specialist"] = steps
     progress_bar.progress(0.6)
     
     # Stage 4: Head of Content
@@ -460,11 +497,12 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     Return the full refined content.
     """
     
-    polished = call_agent("Head of Content", head_prompt, model, api_key)
-    if not polished:
+    polished_raw = call_agent("Head of Content", head_prompt, model, api_key)
+    if not polished_raw:
         return None
-    
+    polished, steps = parse_next_steps(polished_raw)
     results["polished"] = polished
+    next_steps["Head of Content"] = steps
     progress_bar.progress(0.8)
     
     # Stage 5: Editor-in-Chief
@@ -479,11 +517,12 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
     {polished}
     """
     
-    editor_review = call_agent("Editor-in-Chief", editor_prompt, model, api_key)
-    if not editor_review:
+    editor_raw = call_agent("Editor-in-Chief", editor_prompt, model, api_key)
+    if not editor_raw:
         return None
-    
+    editor_review, steps = parse_next_steps(editor_raw)
     results["editor_review"] = editor_review
+    next_steps["Editor-in-Chief"] = steps
     progress_bar.progress(1.0)
     
     # Parse editor review
@@ -509,6 +548,7 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
         results["comments"] = comments
         results["final_title"] = final_title
         results["final_content"] = polished
+        results["next_steps"] = next_steps
         
     except:
         results["approval"] = "Approved"
@@ -516,6 +556,7 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar)
         results["comments"] = "Content meets quality standards."
         results["final_title"] = topic
         results["final_content"] = polished
+        results["next_steps"] = next_steps
     
     status_container.success(f"✨ {datetime.now():%H:%M:%S} - Content generation complete!")
     
@@ -627,72 +668,89 @@ def display_generated_content(results, model, api_key):
         if results.get('comments'):
             st.info(f"💭 Editor's Note: {results['comments']}")
 
-    # Content preview
-    with st.expander(" View Full Content", expanded=True):
-        st.markdown(results['final_content'])
+    # Content preview and downloads
+    with st.container():
+        st.markdown('<div class="content-preview">', unsafe_allow_html=True)
 
-    if results.get('queries'):
-        st.markdown("### Suggested Search Queries")
-        for q in results['queries']:
-            st.markdown(f"- {q}")
+        with st.expander(" View Full Content", expanded=True):
+            st.markdown(results['final_content'])
 
-        dot = "digraph G {root [label=\"" + results['final_title'] + "\"];"
-        for i, q in enumerate(results['queries']):
-            node = f"q{i}"
-            dot += f"root -> {node}; {node} [label=\"{q}\"];"
-        dot += "}"
-        st.graphviz_chart(dot)
+        if results.get('queries'):
+            st.markdown("### Suggested Search Queries")
+            for q in results['queries']:
+                st.markdown(f"- {q}")
 
-    # Download options
-    st.markdown("### Download Content")
-    col1, col2, col3, col4, col5 = st.columns(5)
+            dot = "digraph G {root [label=\"" + results['final_title'] + "\"];"
+            for i, q in enumerate(results['queries']):
+                node = f"q{i}"
+                dot += f"root -> {node}; {node} [label=\"{q}\"];"
+            dot += "}"
+            st.graphviz_chart(dot)
 
-    with col1:
-        create_download_button(
-            results['final_content'],
-            f"{results['final_title'].replace(' ', '_')}.md",
-            "Markdown",
-            "md"
-        )
+        st.markdown("### Download Content")
+        col1, col2, col3, col4, col5 = st.columns(5)
 
-    with col2:
-        create_download_button(
-            results['final_content'],
-            f"{results['final_title'].replace(' ', '_')}.html",
-            "HTML",
-            "html"
-        )
+        with col1:
+            create_download_button(
+                results['final_content'],
+                f"{results['final_title'].replace(' ', '_')}.md",
+                "Markdown",
+                "md"
+            )
 
-    with col3:
-        # Note: DOCX requires python-docx - simplified for demo
-        st.button("Word (.docx)", disabled=True, help="Coming soon")
+        with col2:
+            create_download_button(
+                results['final_content'],
+                f"{results['final_title'].replace(' ', '_')}.html",
+                "HTML",
+                "html"
+            )
 
-    with col4:
-        # Note: PDF requires additional libraries - simplified for demo
-        st.button("PDF", disabled=True, help="Coming soon")
+        with col3:
+            # Note: DOCX requires python-docx - simplified for demo
+            st.button("Word (.docx)", disabled=True, help="Coming soon")
 
-    with col5:
-        create_download_button(
-            results,
-            f"{results['final_title'].replace(' ', '_')}.json",
-            "JSON",
-            "json"
-        )
+        with col4:
+            # Note: PDF requires additional libraries - simplified for demo
+            st.button("PDF", disabled=True, help="Coming soon")
+
+        with col5:
+            create_download_button(
+                results,
+                f"{results['final_title'].replace(' ', '_')}.json",
+                "JSON",
+                "json"
+            )
+
+        st.markdown("</div>", unsafe_allow_html=True)
 
     # Revision section
-    st.markdown("###Request Revisions")
+    st.markdown("### Request Updates")
     with st.form("revision_form"):
-        feedback = st.text_area(
-            "Describe the changes you'd like",
-            placeholder="e.g., Make the introduction shorter and add a stronger call-to-action at the end...",
+        selected_steps = []
+        st.markdown("#### Recommended Next Steps")
+        if results.get('next_steps'):
+            for agent, steps in results['next_steps'].items():
+                if steps:
+                    st.markdown(f"**{agent}**")
+                    for i, step in enumerate(steps):
+                        if st.checkbox(step, key=f"{agent}_{i}"):
+                            selected_steps.append(step)
+
+        feedback_extra = st.text_area(
+            "Additional instructions",
+            placeholder="Add any extra notes...",
         )
 
-        if st.form_submit_button("Apply Revisions"):
-            if feedback:
+        if st.form_submit_button("Request updates"):
+            compiled = "\n".join(selected_steps)
+            if feedback_extra:
+                compiled = compiled + ("\n" if compiled else "") + feedback_extra
+            if compiled:
                 with st.spinner("Applying your revisions..."):
                     revision_result = apply_revision(
                         results['final_content'],
-                        feedback,
+                        compiled,
                         model,
                         api_key
                     )
@@ -707,7 +765,7 @@ def display_generated_content(results, model, api_key):
                         st.session_state.history.append({
                             "version": len(st.session_state.history) + 1,
                             "timestamp": datetime.now().isoformat(),
-                            "revision_feedback": feedback,
+                            "revision_feedback": compiled,
                             "results": st.session_state.current_content.copy()
                         })
 
@@ -723,15 +781,18 @@ def main():
     with st.sidebar:
         st.markdown("###Configuration")
         api_key = st.text_input("OpenAI API Key", type="password", help="Your API key is not stored")
-        
+
         if st.session_state.current_content:
             st.markdown("###Current Session")
             st.markdown(f"**Title:** {st.session_state.current_content.get('final_title', 'N/A')}")
             st.markdown(f"**Score:** {st.session_state.current_content.get('score', 'N/A')}")
             st.markdown(f"**Status:** {st.session_state.current_content.get('approval', 'N/A')}")
+
+        # Container to display pipeline status messages
+        status_container = st.container()
     
     # Main content area
-    tab1, tab2, tab3, tab4 = st.tabs(["Create Content", "Chat with Agents", "Version History", "Help"])
+    tab1, tab2, tab3, tab4 = st.tabs(["Create Content", "Talk with the team", "Version History", "Help"])
     
     with tab1:
         if not api_key:
@@ -824,7 +885,7 @@ def main():
             }
             
             # Create containers for status and progress
-            status_container = st.empty()
+            status_container.empty()
             progress_bar = st.progress(0)
             
             # Run the pipeline
@@ -849,10 +910,10 @@ def main():
             st.warning("Please enter your OpenAI API key to use agent chat.")
             return
             
-        st.markdown("### 💬 Chat with AI Agents")
+        st.markdown("### 💬 Talk with the team")
         
         if not st.session_state.current_content:
-            st.info("Generate content first to chat with the AI agents about it.")
+            st.info("Generate content first to talk with the team about it.")
             return
         
         # Agent selector
@@ -965,7 +1026,7 @@ def main():
         - Include relevant keywords for SEO optimization
         - Upload reference materials for more accurate content
         - Use the revision feature to fine-tune the output
-        - Chat with individual agents for detailed insights
+        - Talk with the team members for detailed insights
         
         """)
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -350,18 +350,20 @@ def call_agent(agent_name, prompt, model, api_key, context=""):
         st.error(f"Error calling {agent_name}: {str(e)}")
         return None
 
-def parse_queries(text):
-    """Extract list of queries from SEO Specialist output"""
-    queries = []
+def parse_queries(text: str) -> list[str]:
+    """Extract list of search queries from the SEO Specialist output."""
+
+    queries: list[str] = []
+
+    bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
+
     for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        # Lines starting with bullets or numbers likely represent queries
-        if re.match(r"^[-*\d+.]+\s", line):
-            query = re.sub(r"^[-*\d+.]+\s*", "", line)
+        match = bullet_pattern.match(line.strip())
+        if match:
+            query = match.group(1).strip()
             if query:
                 queries.append(query)
+
     return queries
 
 def run_content_pipeline(inputs, model, api_key, status_container, progress_bar):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -779,11 +779,11 @@ def main():
     
     # Sidebar for API key
     with st.sidebar:
-        st.markdown("###Configuration")
+        st.markdown("### Configuration")
         api_key = st.text_input("OpenAI API Key", type="password", help="Your API key is not stored")
 
         if st.session_state.current_content:
-            st.markdown("###Current Session")
+            st.markdown("### Current Session")
             st.markdown(f"**Title:** {st.session_state.current_content.get('final_title', 'N/A')}")
             st.markdown(f"**Score:** {st.session_state.current_content.get('score', 'N/A')}")
             st.markdown(f"**Status:** {st.session_state.current_content.get('approval', 'N/A')}")
@@ -1003,14 +1003,14 @@ def main():
     
     with tab4:
         st.markdown("""
-        ###Getting Started
+        ### Getting Started
         
         1. **Enter your OpenAI API Key** in the sidebar (it's not stored)
         2. **Fill out the content request form** with your requirements
         3. **Select an AI model** (GPT-4 recommended for best quality)
         4. **Click Generate Content** and watch your AI team work!
         
-        ###The AI Team
+        ### The AI Team
         
         Your content goes through 5 specialist AI agents:
         
@@ -1020,7 +1020,7 @@ def main():
         4. **Head of Content** - Ensures brand alignment
         5. **Editor-in-Chief** - Final review and approval
         
-        ###Tips for Best Results
+        ### Tips for Best Results
         
         - Be specific with your topic and key messages
         - Include relevant keywords for SEO optimization


### PR DESCRIPTION
## Summary
- parse queries from SEO Specialist output
- visualize suggested queries with a graphviz diagram

## Testing
- `pytest -q`
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684202e6926c8333bafb7185294bd0cb