### PR TITLE
Improve search query visualization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-docx==1.1.0
 markdown==3.5.2
 pypdf2==3.0.1
 pdfplumber==0.10.3
+pyvis==0.3.2
+networkx==3.2.1

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,6 +8,9 @@ from docx import Document
 import markdown
 import base64
 import re
+import networkx as nx
+from pyvis.network import Network
+import streamlit.components.v1 as components
 
 # Page configuration
 st.set_page_config(
@@ -765,12 +768,18 @@ def display_generated_content(results, model, api_key, session_placeholder):
             for q in results['queries']:
                 st.markdown(f"- {q}")
 
-            dot = "digraph G {root [label=\"" + results['final_title'] + "\"];"
+            # Build interactive network graph
+            G = nx.DiGraph()
+            G.add_node("root", label=results['final_title'])
             for i, q in enumerate(results['queries']):
                 node = f"q{i}"
-                dot += f"root -> {node}; {node} [label=\"{q}\"];"
-            dot += "}"
-            st.graphviz_chart(dot)
+                G.add_node(node, label=q)
+                G.add_edge("root", node)
+
+            net = Network(height="400px", width="100%", directed=True)
+            net.from_nx(G)
+            html = net.generate_html()
+            components.html(html, height=450, scrolling=True)
 
         st.markdown("### Download Content")
         col1, col2, col3, col4, col5 = st.columns(5)


### PR DESCRIPTION
## Summary
- add `pyvis` and `networkx` dependencies
- display search queries using an interactive PyVis network graph

## Testing
- `python -m py_compile streamlit_app.py`
- `python - <<'EOF'
import networkx as nx
from pyvis.network import Network
print('ok')
EOF` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68421d0adf7c8333b13dae4e6a0207fa