### PR TITLE
Add Planning Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ The model selector offers three options that map to the corresponding OpenAI end
 | `o3`   | `o3-2025-04-16` |
 
 Choose whichever model best meets your quality and speed requirements when generating or revising content.
+
+### Planning Mode
+
+When you only need a strategic brief, enable **Planning Mode** in the app. This runs just the Strategist, SEO Specialist and Head of Content agents to deliver a content plan with up to three related topic fanouts.


### PR DESCRIPTION
## Summary
- allow `run_content_pipeline` to run in planning mode
- update form to toggle planning mode
- skip writer and editor stages when planning mode is enabled
- add mention of planning mode in help text and README

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684222869034833393b6db87753584a0