### PR TITLE
Improve query parsing and style for graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A simple Streamlit app that shows how to build a chatbot using newer GPT-4 based
    $ pip install -r requirements.txt
    ```
 
+   If you encounter `ModuleNotFoundError: No module named 'networkx'`,
+   double-check that the requirements were installed successfully.
+
 2. Run the app
 
    ```

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -437,14 +437,33 @@ def parse_queries(text: str) -> list[str]:
     queries: list[str] = []
     bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
 
+    capture = False
     for line in text.splitlines():
-        match = bullet_pattern.match(line.strip())
-        if match:
-            query = match.group(1).strip()
-            if query:
-                queries.append(query)
+        lower = line.lower().strip()
+        if "query" in lower and ":" in lower:
+            capture = True
+            continue
+        if capture:
+            if not line.strip():
+                break
+            match = bullet_pattern.match(line)
+            if match:
+                query = match.group(1).strip()
+                if query:
+                    queries.append(query)
+            else:
+                # Stop if we reach a non-bullet line
+                break
 
-    return queries
+    seen = set()
+    unique = []
+    for q in queries:
+        qnorm = q.lower()
+        if qnorm not in seen:
+            unique.append(q)
+            seen.add(qnorm)
+
+    return unique
 
 def pseudo_embedding(text: str, dim: int = 8) -> list[float]:
     """Deterministic pseudo embedding based on text hash."""
@@ -898,7 +917,11 @@ def display_generated_content(results, model, api_key, session_placeholder):
     # Status and score
     col1, col2 = st.columns([1, 3])
     with col1:
-        score_value = int(results['score'].split('/')[0])
+        score_raw = results.get('score', 'N/A')
+        score_value = 0
+        match = re.search(r"(\d+)", str(score_raw))
+        if match:
+            score_value = int(match.group(1))
         score_class = "high" if score_value >= 8 else "medium" if score_value >= 6 else "low"
         st.markdown(
             f'<div class="score-badge score-{score_class}">Score: {results["score"]}</div>',
@@ -957,6 +980,16 @@ def display_generated_content(results, model, api_key, session_placeholder):
 
             net.show_buttons(filter_=['interaction'])
             html = net.generate_html()
+
+            custom_style = """
+            <style>
+            body {background-color: #f7f6ed; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;}
+            .query-card {background-color: #FFFFFF; border-radius: 0.75rem; padding: 0.5rem 0.75rem; font-size: 0.85rem;}
+            .query-text {font-weight: 600; margin-bottom: 0.25rem;}
+            .query-meta {font-size: 0.75rem; color: #555;}
+            </style>
+            """
+            html = html.replace('</head>', custom_style + '</head>')
 
             buttons = '''
             <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>


### PR DESCRIPTION
## Summary
- refine `parse_queries` to extract bullet lists only under a queries heading and de-duplicate results
- inject custom CSS into the network graph HTML so styling matches the rest of the app

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest -q`
- `pip install networkx==3.2.1` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6842257c789c83339004a55042e0d2c3