### PR TITLE
Add search query output in all modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Choose whichever model best meets your quality and speed requirements when gener
 ### Planning Mode
 
 When you only need a strategic brief, enable **Planning Mode** in the app. This runs just the Strategist, SEO Specialist and Head of Content agents to deliver a content plan with up to three related topic fanouts.
+
+In both regular and Planning Mode, the SEO Specialist now lists suggested search queries under a **Search Queries** heading so you can see keyword opportunities and an interactive fan-out visualization.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -682,7 +682,8 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar,
         Analyze search opportunities for the topic "{topic}" based on this strategy:
         {strategy}
 
-        Provide up to 3 high-potential query fanouts and brief notes on how they support the overall plan.
+        Provide up to 3 high-potential search query fanouts.
+        Return them as bullet points under the heading "Search Queries:" with brief notes on how each supports the overall plan.
         """
     else:
         seo_prompt = f"""
@@ -692,6 +693,8 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar,
         {draft}
 
         Return the full content with SEO improvements applied.
+
+        After the final content, list up to 3 related search queries as bullet points under the heading "Search Queries:".
         """
 
     seo_raw = call_agent("SEO Specialist", seo_prompt, model, api_key)


### PR DESCRIPTION
## Summary
- update SEO Specialist prompts to always output search query suggestions
- document search query output in README

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68422b65db2c8333b739904a243cd50c