### PR TITLE
Ensure agents see all reference materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ The suggestions appear in a table with their fanout type (reformulation, implici
 ### Reference Sharing Across Agents
 
 Uploaded files and all form inputs are stitched together into a context block that gets sent to **every** AI agent. This keeps the Strategist, SEO Specialist, Specialist Writer, Head of Content and Editor-in-Chief on the same page. The combined context also appears in the chat prompts so you can see exactly what they're working from.
+The app also loads the Markdown files in the `knowledge/` folder and appends them to that shared context so every agent consistently references the brand messaging, style guide and editorial process.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ When you only need a strategic brief, enable **Planning Mode** in the app. This 
 The SEO Specialist now runs before any drafting begins so you can review keyword opportunities up front.
 In both regular and Planning Mode it lists suggested search queries under a **Search Queries** heading with a fan-out graph.
 The suggestions appear in a table with their fanout type (reformulation, implicit, comparative, entity expansion, personalized, temporal, location, user intent or technical) and cosine similarity score. You can download the full list as a CSV file for further analysis.
+
+### Reference Sharing Across Agents
+
+Uploaded files and all form inputs are stitched together into a context block that gets sent to **every** AI agent. This keeps the Strategist, SEO Specialist, Specialist Writer, Head of Content and Editor-in-Chief on the same page. The combined context also appears in the chat prompts so you can see exactly what they're working from.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -438,26 +438,30 @@ def parse_queries(text: str) -> list[str]:
     bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
 
     capture = False
+    found = False
     for line in text.splitlines():
         lower = line.lower().strip()
         if not capture:
-            if "query" in lower and (":" in lower or lower.startswith("#")):
+            if "search queries" in lower or (
+                "query" in lower and (":" in lower or lower.startswith("#"))
+            ):
                 capture = True
                 continue
-            if "search queries" in lower:
-                capture = True
-                continue
-        if capture:
+        else:
             if not line.strip():
-                break
+                if found:
+                    break
+                continue
+
             match = bullet_pattern.match(line)
             if match:
                 query = match.group(1).strip()
                 if query:
                     queries.append(query)
+                    found = True
             else:
-                # Stop if we reach a non-bullet line
-                break
+                if found:
+                    break
 
     seen = set()
     unique = []

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,6 +14,7 @@ import streamlit.components.v1 as components
 import hashlib
 import random
 import math
+import os
 
 
 # Page configuration
@@ -390,6 +391,20 @@ def extract_text_from_file(uploaded_file):
     except Exception as e:
         return f"Error reading file: {str(e)}"
 
+def load_knowledge(directory: str = "knowledge") -> str:
+    """Concatenate Markdown files from the knowledge directory."""
+    content = ""
+    try:
+        for name in sorted(os.listdir(directory)):
+            path = os.path.join(directory, name)
+            if os.path.isfile(path) and name.endswith(".md"):
+                with open(path, "r") as f:
+                    data = f.read().strip()
+                content += f"\n\n--- {name} ---\n{data}"
+    except Exception:
+        pass
+    return content
+
 def call_agent(agent_name, prompt, model, api_key, context=""):
     """Make API call to OpenAI for an agent"""
     try:
@@ -626,6 +641,7 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar,
     keywords = inputs["keywords"]
     compliance = inputs["compliance"]
     references = inputs["references"]
+    knowledge = load_knowledge()
     context_info = (
         f"Content Type: {content_type}\n"
         f"Topic: {topic}\n"
@@ -635,6 +651,7 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar,
         f"Brand Voice: {brand_voice or 'Professional, data-driven, friendly'}\n"
         f"SEO Keywords: {keywords}\n"
         f"Compliance Requirements: {compliance}\n"
+        f"Knowledge Base:\n{knowledge[:1000] + '...' if len(knowledge) > 1000 else knowledge}\n"
         f"Reference Materials:\n"
         f"{references[:1000] + '...' if len(references) > 1000 else references}"
     )

--- a/tests/test_parse_queries.py
+++ b/tests/test_parse_queries.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+import sys
+import types
+import re
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+path = os.path.join(ROOT, "streamlit_app.py")
+with open(path, "r") as f:
+    source = f.read()
+
+pattern = re.compile(r"def parse_queries.*?return unique", re.S)
+match = pattern.search(source)
+assert match, "parse_queries function not found"
+namespace = {}
+exec(match.group(0), {"re": re}, namespace)
+parse_queries = namespace["parse_queries"]
+
+class ParseQueriesTest(unittest.TestCase):
+    def test_blank_line_after_heading(self):
+        text = """Search Queries:\n\n- Reformulation: what is fasttrace?\n- Implicit: tracing library benefits"""
+        expected = [
+            "Reformulation: what is fasttrace?",
+            "Implicit: tracing library benefits",
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
+    def test_non_bullet_lines(self):
+        text = """Search Queries:\n1. Why use FastTrace?\n2. FastTrace vs Zipkin\nNotes:"""
+        expected = [
+            "Why use FastTrace?",
+            "FastTrace vs Zipkin",
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- share a `context_info` block with every agent
- store the context in session results
- include context when requesting revisions
- include context in sidebar and main chat prompts
- document reference sharing

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684230723ba48333b7c9c90cca017f1d