### PR TITLE
Improve query validation

### DIFF
--- a/tests/test_parse_queries.py
+++ b/tests/test_parse_queries.py
@@ -22,16 +22,16 @@ class ParseQueriesTest(unittest.TestCase):
     def test_blank_line_after_heading(self):
         text = """Search Queries:\n\n- Reformulation: what is fasttrace?\n- Implicit: tracing library benefits"""
         expected = [
-            "Reformulation: what is fasttrace?",
-            "Implicit: tracing library benefits",
+            {"type": "reformulation", "query": "what is fasttrace?"},
+            {"type": "implicit", "query": "tracing library benefits"},
         ]
         self.assertEqual(parse_queries(text), expected)
 
     def test_non_bullet_lines(self):
         text = """Search Queries:\n1. Why use FastTrace?\n2. FastTrace vs Zipkin\nNotes:"""
         expected = [
-            "Why use FastTrace?",
-            "FastTrace vs Zipkin",
+            {"type": "", "query": "Why use FastTrace?"},
+            {"type": "", "query": "FastTrace vs Zipkin"},
         ]
         self.assertEqual(parse_queries(text), expected)
 


### PR DESCRIPTION
## Summary
- parse SEO queries into type/query pairs
- surface provided types in UI and verify them with heuristic classification
- highlight mismatched suggestions in table and graph
- update tests for new parse format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684239d35b788333a2d78731d8cb4b9e