### PR TITLE
Improve query validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ When you only need a strategic brief, enable **Planning Mode** in the app. This 
 
 The SEO Specialist now runs before any drafting begins so you can review keyword opportunities up front.
 In both regular and Planning Mode it lists suggested search queries under a **Search Queries** heading with a fan-out graph.
-The suggestions appear in a table with their fanout type (reformulation, implicit, comparative, entity expansion, personalized, temporal, location, user intent or technical) and cosine similarity score. You can download the full list as a CSV file for further analysis.
+Each bullet follows the `<Type>: <query>` format so the app can verify that the provided type matches the query intent. The table highlights mismatches and shows cosine similarity scores. You can download the full list as a CSV file for further analysis.
+If fewer than 20 queries are supplied, the app displays a warning so you can rerun the SEO agent.
 
 ### Reference Sharing Across Agents
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -250,10 +250,10 @@ When you finish, add a section titled 'Recommended Next Steps:' followed by a bu
     Your RAISE-R Workflow:
     1) **Request-clarify**: Understand the content's goal and target metrics
     2) **Audit current surface**: Analyze SERP/AI Mode snapshots and competing passages
-    3) **Infer fan-out landscape**: Generate 6+ synthetic queries spanning related, comparative, and entity-expanded types
-    4) **Score semantic gaps**: Identify where content fails to align with search intent
-    5) **Engineer relevance**: Optimize for both traditional SEO and AI snippet capture
-    6) **Review & report**: Provide actionable improvements with expected impact
+    3) **Infer fan-out landscape**: Generate 20+ synthetic queries spanning all query fan out types. Things that actual humans would think/say/type in a chatbot.
+    4) **Score semantic gaps**: Identify where content fails to align with search intent and report this out.
+    5) **Engineer relevance**: Optimize for both traditional SEO and AI snippet capture. Do this by mapping cosine similarity and chunking.
+    6) **Review & report**: Report everything out in its proper place.
     
     Optimization Approach:
     - **Snippet Sculpting**: Position key value props in first 160 characters for AI snippet capture
@@ -274,6 +274,7 @@ When you finish, add a section titled 'Recommended Next Steps:' followed by a bu
     - Bullet points over prose
     - Flag uncertainty rather than fabricate metrics
     - Include measurement hooks for citation frequency and answer prominence
+    - Under a **Search Queries** heading, list each suggestion as `<Type>: <query>` and double-check that the type label matches the query intent.
     
     Never sacrifice readability for traditional SEO metrics. The best content serves users first and search engines second.
 
@@ -446,11 +447,17 @@ def parse_next_steps(output):
         return content.strip(), steps
     return output.strip(), []
 
-def parse_queries(text: str) -> list[str]:
-    """Extract search queries from SEO Specialist output."""
+def parse_queries(text: str) -> list[dict]:
+    """Extract search queries from SEO Specialist output.
 
-    queries: list[str] = []
+    Returns a list of dictionaries with ``type`` and ``query`` keys so we can
+    validate how the SEO agent labeled each suggestion."""
+
+    queries: list[dict] = []
     bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
+    typed_pattern = re.compile(
+        r"(?P<type>[^:]+):\s*(?P<query>.*?)(?:\s+-\s*.*)?$"
+    )
 
     capture = False
     found = False
@@ -470,9 +477,17 @@ def parse_queries(text: str) -> list[str]:
 
             match = bullet_pattern.match(line)
             if match:
-                query = match.group(1).strip()
-                if query:
-                    queries.append(query)
+                item = match.group(1).strip()
+                tmatch = typed_pattern.match(item)
+                if tmatch:
+                    qtype = tmatch.group("type").strip().lower().replace(" ", "_")
+                    qtext = tmatch.group("query").strip()
+                else:
+                    qtype = ""
+                    qtext = item
+
+                if qtext:
+                    queries.append({"type": qtype, "query": qtext})
                     found = True
             else:
                 if found:
@@ -481,7 +496,7 @@ def parse_queries(text: str) -> list[str]:
     seen = set()
     unique = []
     for q in queries:
-        qnorm = q.lower()
+        qnorm = q["query"].lower()
         if qnorm not in seen:
             unique.append(q)
             seen.add(qnorm)
@@ -506,26 +521,34 @@ def cosine_sim(v1: list[float], v2: list[float]) -> float:
 
 
 def classify_query(query: str) -> str:
-    """Heuristically classify a query into fanout types."""
+    """Heuristically classify a query into fan-out types."""
     q = query.lower()
 
-    if any(t in q for t in [" vs ", "compare", "versus"]):
+    if any(t in q for t in [" vs ", "versus", "compare", "difference", "better than"]):
         return "comparative"
-    if any(t in q for t in ["near me", "in ", "location", "at "]):
+
+    if re.search(r"\b(near me|in [a-z]+|at [a-z]+|location|city|country)\b", q):
         return "location"
-    if any(t in q for t in ["202", "today", "latest", "year", "month"]):
+
+    if re.search(r"\b(20\d{2}|today|latest|this year|this month)\b", q) or re.search(r"\b\d+[- ]?(day|week|month|year)s?\b", q):
         return "temporal"
-    if any(t in q for t in ["my ", "for me", "i ", "personalized"]):
+
+    if re.search(r"\b(my|for me|i |personalized|best for me|should i)\b", q):
         return "personalized"
-    if any(t in q for t in ["error", "install", "setup", "troubleshoot", "code", "configuration"]):
+
+    if any(t in q for t in ["error", "install", "setup", "troubleshoot", "code", "configuration", "how to", "fix"]):
         return "technical"
-    if any(t in q for t in ["alternative", "similar", "related"]):
+
+    if any(t in q for t in ["alternative", "similar", "related", "competitor"]):
         return "entity_expansion"
-    if any(t in q for t in ["what is", "define", "definition"]):
+
+    if any(t in q for t in ["what is", "define", "definition", "meaning"]):
         return "reformulation"
+
     first = q.split()[0] if q.split() else ""
     if first in ["how", "why", "what", "where", "when", "who"]:
         return "user_intent"
+
     return "implicit"
 
 
@@ -732,7 +755,10 @@ def run_content_pipeline(inputs, model, api_key, status_container, progress_bar,
     seo_content, steps = parse_next_steps(seo_raw)
     results["seo_content"] = seo_content
     st.session_state.current_content["seo_content"] = seo_content
-    results["queries"] = parse_queries(seo_content)
+
+    parsed_queries = parse_queries(seo_content)
+    results["queries_typed"] = parsed_queries
+    results["queries"] = [q["query"] for q in parsed_queries]
     next_steps["SEO Specialist"] = steps
     st.session_state.agent_status["SEO Specialist"] = "Completed"
     refresh_current_session(session_placeholder)
@@ -1021,10 +1047,13 @@ def display_generated_content(results, model, api_key, session_placeholder):
         with st.expander(" View Full Content", expanded=True):
             st.markdown(results['final_content'])
             
-        if results.get('queries'):
+        if results.get('queries_typed'):
             st.markdown("### Suggested Search Queries")
-            for q in results['queries']:
-                st.markdown(f"- {q}")
+            if len(results['queries_typed']) < 20:
+                st.warning("SEO Specialist produced fewer than 20 queries.")
+            for q in results['queries_typed']:
+                label = f"{q['type']}: " if q['type'] else ""
+                st.markdown(f"- {label}{q['query']}")
 
             # Build interactive network graph with query fan-out
             G, node_info = build_query_graph(
@@ -1034,21 +1063,26 @@ def display_generated_content(results, model, api_key, session_placeholder):
                 levels=3
             )
 
+            provided_map = {q['query']: q['type'] for q in results.get('queries_typed', [])}
             table_rows = []
             for nid, data in node_info.items():
                 if nid == "n0":
                     continue
                 q_text = data['text']
-                row_type = classify_query(q_text)
+                auto_type = classify_query(q_text)
+                provided = provided_map.get(q_text, "")
+                logic_check = "✓" if not provided or provided == auto_type else "⚠"
                 table_rows.append({
-                    "Type": row_type,
+                    "Provided": provided or "-",
+                    "Auto": auto_type,
+                    "Logic": logic_check,
                     "Query": q_text,
                     "Similarity": round(data['similarity'], 2)
                 })
 
             st.table(table_rows)
-            csv_content = "Type,Query,Similarity\n" + "\n".join(
-                f"{r['Type']},{r['Query']},{r['Similarity']}" for r in table_rows
+            csv_content = "Provided,Auto,Logic,Query,Similarity\n" + "\n".join(
+                f"{r['Provided']},{r['Auto']},{r['Logic']},{r['Query']},{r['Similarity']}" for r in table_rows
             )
             results['queries_csv'] = csv_content
 
@@ -1061,12 +1095,18 @@ def display_generated_content(results, model, api_key, session_placeholder):
                     f"<div class='query-meta'>Cosine similarity: {data['similarity']:.2f}</div>"
                     "</div>"
                 )
+                provided = provided_map.get(data['text'])
+                auto = classify_query(data['text'])
+                color = None
+                if provided:
+                    color = '#99e599' if provided == auto else '#f9d6d5'
                 net.add_node(
                     nid,
                     label=data['text'],
                     title=title_html,
                     shape='box',
                     size=size,
+                    color=color,
                 )
             for src, dst in G.edges():
                 sim = node_info[dst]['similarity']

--- a/tests/test_classify_query.py
+++ b/tests/test_classify_query.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+import sys
+import re
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+path = os.path.join(ROOT, "streamlit_app.py")
+with open(path, "r") as f:
+    source = f.read()
+
+pattern = re.compile(r"def classify_query.*?return \"implicit\"", re.S)
+match = pattern.search(source)
+assert match, "classify_query function not found"
+namespace = {}
+exec(match.group(0), {"re": re}, namespace)
+classify_query = namespace["classify_query"]
+
+
+class ClassifyQueryTest(unittest.TestCase):
+    def test_temporal_90_day(self):
+        self.assertEqual(classify_query("90-day SEO roadmap"), "temporal")
+
+    def test_location_city(self):
+        self.assertEqual(classify_query("meetups in Denver"), "location")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parse_queries.py
+++ b/tests/test_parse_queries.py
@@ -22,16 +22,24 @@ class ParseQueriesTest(unittest.TestCase):
     def test_blank_line_after_heading(self):
         text = """Search Queries:\n\n- Reformulation: what is fasttrace?\n- Implicit: tracing library benefits"""
         expected = [
-            "Reformulation: what is fasttrace?",
-            "Implicit: tracing library benefits",
+            {"type": "reformulation", "query": "what is fasttrace?"},
+            {"type": "implicit", "query": "tracing library benefits"},
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
+    def test_query_with_note(self):
+        text = """Search Queries:\n- Comparative: fasttrace vs jaeger - note\n- Reformulation: what is fasttrace - explanation"""
+        expected = [
+            {"type": "comparative", "query": "fasttrace vs jaeger"},
+            {"type": "reformulation", "query": "what is fasttrace"},
         ]
         self.assertEqual(parse_queries(text), expected)
 
     def test_non_bullet_lines(self):
         text = """Search Queries:\n1. Why use FastTrace?\n2. FastTrace vs Zipkin\nNotes:"""
         expected = [
-            "Why use FastTrace?",
-            "FastTrace vs Zipkin",
+            {"type": "", "query": "Why use FastTrace?"},
+            {"type": "", "query": "FastTrace vs Zipkin"},
         ]
         self.assertEqual(parse_queries(text), expected)
 


### PR DESCRIPTION
## Summary
- refine parse logic to ignore notes after dashes
- expand heuristics in classify_query for better detection
- add query count warning and validation tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684239d35b788333a2d78731d8cb4b9e