### PR TITLE
Improve query parsing robustness

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -456,7 +456,7 @@ def parse_queries(text: str) -> list[dict]:
     any explanation that follows a dash."""
 
     queries: list[dict] = []
-    bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
+    bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+[.)])\s*(.+)")
     typed_pattern = re.compile(r"(?P<type>[^:]+):\s*(?P<rest>.+)")
     capture = False
     found = False
@@ -470,8 +470,6 @@ def parse_queries(text: str) -> list[dict]:
                 continue
         else:
             if not line.strip():
-                if found:
-                    break
                 continue
 
             match = bullet_pattern.match(line)

--- a/tests/test_parse_queries.py
+++ b/tests/test_parse_queries.py
@@ -43,5 +43,13 @@ class ParseQueriesTest(unittest.TestCase):
         ]
         self.assertEqual(parse_queries(text), expected)
 
+    def test_numbered_parentheses_and_blank_lines(self):
+        text = """Search Queries:\n1) Comparative: fasttrace vs jaeger\n\n2) Reformulation: what is fasttrace - expl"""
+        expected = [
+            {"type": "comparative", "query": "fasttrace vs jaeger", "note": ""},
+            {"type": "reformulation", "query": "what is fasttrace", "note": "expl"},
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- tweak query bullet regex to handle `1)` style bullets
- ignore blank lines while parsing SEO results
- cover new scenarios in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f2445ecc8333a0ce3fd3a8c0f116