### PR TITLE
Improve query parsing robustness

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -456,49 +456,74 @@ def parse_queries(text: str) -> list[dict]:
     any explanation that follows a dash."""
 
     queries: list[dict] = []
-    bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(.+)")
-    typed_pattern = re.compile(r"(?P<type>[^:]+):\s*(?P<rest>.+)")
+    bullet_pattern = re.compile(r"^\s*(?:[-*]|\d+[.)]|\d+:)\s*(.+)")
+    typed_pattern = re.compile(r"(?P<type>[^:-]+)\s*[:-]\s*(?P<rest>.+)")
+    known_types = {
+        "reformulation",
+        "implicit",
+        "comparative",
+        "entity_expansion",
+        "personalized",
+        "temporal",
+        "location",
+        "user_intent",
+        "technical",
+    }
     capture = False
     found = False
     for line in text.splitlines():
         lower = line.lower().strip()
+        match = bullet_pattern.match(line)
         if not capture:
-            if "search queries" in lower or (
+            heading = "search queries" in lower or (
                 "query" in lower and (":" in lower or lower.startswith("#"))
-            ):
-                capture = True
-                continue
-        else:
-            if not line.strip():
-                if found:
-                    break
-                continue
-
-            match = bullet_pattern.match(line)
+            )
+            start_list = False
             if match:
                 item = match.group(1).strip()
                 tmatch = typed_pattern.match(item)
                 if tmatch:
-                    qtype = tmatch.group("type").strip().lower().replace(" ", "_")
-                    rest = tmatch.group("rest").strip()
+                    qtype_check = tmatch.group("type").strip().lower().replace(" ", "_")
+                    if qtype_check in known_types:
+                        start_list = True
+            if heading or start_list:
+                capture = True
+                if start_list:
+                    # Fall through to process this line as a query
+                    pass
                 else:
-                    qtype = ""
+                    continue
+        if not line.strip():
+            continue
+
+        match = bullet_pattern.match(line)
+        if match:
+            item = match.group(1).strip()
+            tmatch = typed_pattern.match(item)
+            if tmatch:
+                qtype = tmatch.group("type").strip().lower().replace(" ", "_")
+                rest = tmatch.group("rest").strip()
+                if qtype not in known_types:
                     rest = item
-
-                if " - " in rest:
-                    qtext, note = rest.split(" - ", 1)
-                    qtext = qtext.strip()
-                    note = note.strip()
-                else:
-                    qtext = rest
-                    note = ""
-
-                if qtext:
-                    queries.append({"type": qtype, "query": qtext, "note": note})
-                    found = True
+                    qtype = ""
             else:
-                if found:
-                    break
+                qtype = ""
+                rest = item
+
+            if " - " in rest:
+                qtext, note = rest.split(" - ", 1)
+                qtext = qtext.strip()
+                note = note.strip()
+            else:
+                qtext = rest
+                note = ""
+
+            if qtext:
+                queries.append({"type": qtype, "query": qtext, "note": note})
+                found = True
+        else:
+            if found:
+                break
 
     seen = set()
     unique = []

--- a/tests/test_parse_queries.py
+++ b/tests/test_parse_queries.py
@@ -43,5 +43,21 @@ class ParseQueriesTest(unittest.TestCase):
         ]
         self.assertEqual(parse_queries(text), expected)
 
+    def test_numbered_parentheses_and_blank_lines(self):
+        text = """Search Queries:\n1) Comparative: fasttrace vs jaeger\n\n2) Reformulation: what is fasttrace - expl"""
+        expected = [
+            {"type": "comparative", "query": "fasttrace vs jaeger", "note": ""},
+            {"type": "reformulation", "query": "what is fasttrace", "note": "expl"},
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
+    def test_number_colon_and_hyphen_type(self):
+        text = """Search Queries:\n1: Comparative - fasttrace vs jaeger\n2: Implicit - tracing library"""
+        expected = [
+            {"type": "comparative", "query": "fasttrace vs jaeger", "note": ""},
+            {"type": "implicit", "query": "tracing library", "note": ""},
+        ]
+        self.assertEqual(parse_queries(text), expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle bullet numbers ending with a colon
- detect query lists even if no heading is present
- support hyphen separators between query type and text
- expand parser test coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f2445ecc8333a0ce3fd3a8c0f116